### PR TITLE
Fix Pixel Shift

### DIFF
--- a/src/app/components/general/table/components/table/table.component.html
+++ b/src/app/components/general/table/components/table/table.component.html
@@ -9,6 +9,7 @@
     [rowsPerPageOptions]="rowsPerPageOptions"
     [rows]="paginateRows"
     [autoLayout]="false"
+    [rowTrackBy]="rowTrackBy"
   >
     <!-- Global filter-->
     <ng-template pTemplate="caption" *ngIf="showFilter || headerText">

--- a/src/app/components/general/table/components/table/table.component.ts
+++ b/src/app/components/general/table/components/table/table.component.ts
@@ -44,6 +44,8 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
   /** Shows a dropdown with how many results per page */
   @Input() rowsPerPageOptions: number[] | undefined;
 
+  @Input() rowTrackBy?: Function;
+
   @Input() compact = false;
 
   public columnWidthsPercent: number[] | null = null;
@@ -121,7 +123,7 @@ export class TableComponent implements OnInit, OnChanges, OnDestroy {
     if (!tableWidth) {
       return null;
     }
-    return widthsPx.map(x => Math.floor((x / tableWidth) * 100000) / 1000);
+    return widthsPx.map(x => Math.floor((x / tableWidth) * 100));
   }
 
   ngOnDestroy() {}


### PR DESCRIPTION
Fixed width percentage error caused by math on truncating decimals in a loop (get from dom, recalculate, click a thing, get from dom recalculate, click again, etc...)

Added track by functionality to stop DOM rewriting unchanged elements.