### PR TITLE
swap TS Lint for ESLint (VSCode)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
   "recommendations": [
     "nrwl.angular-console",
     "angular.ng-template",
-    "ms-vscode.vscode-typescript-tslint-plugin",
+    "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
     "firsttris.vscode-jest-runner"
   ]

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ npx scully serve
 ### VSCode Tools
 
 - Prettier: https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode
-- TS Lint: https://marketplace.visualstudio.com/items?itemName=eg2.tslint
+- ESLint: https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
 
 ### Visual Studio Tools
 


### PR DESCRIPTION
TS Lint is deprecated, so we're switching to ESLint